### PR TITLE
fix: skip mounts when building usb

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,4 @@
     opts: "{{ item.value.opts }}"
     state: "{{ item.value.state }}"
   with_dict: "{{ mount_points }}"
+  tags: usb


### PR DESCRIPTION
Skip role when building USB image as it does not make sense - will be triggered on install to physical disk